### PR TITLE
Remove dup model info in sms router.conf

### DIFF
--- a/adapters/a10_thunder/conf/sms_router.conf
+++ b/adapters/a10_thunder/conf/sms_router.conf
@@ -1,3 +1,3 @@
-#A10 Thunder
+# A10 Thunder
 path                                    a10_thunder
 asset-script-name                       a10_thunder_mgmt.php

--- a/adapters/a10_thunder/conf/sms_router.conf
+++ b/adapters/a10_thunder/conf/sms_router.conf
@@ -1,4 +1,3 @@
 #A10 Thunder
-model                                   80000:80001
 path                                    a10_thunder
 asset-script-name                       a10_thunder_mgmt.php

--- a/adapters/a10_thunder_axapi/conf/sms_router.conf
+++ b/adapters/a10_thunder_axapi/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # A10 Thunder aXAPI
-model                                   80000:80002
 path                                    a10_thunder_axapi
 asset-script-name                       a10_thunder_axapi_mgmt.php
 

--- a/adapters/adtran_generic/conf/sms_router.conf
+++ b/adapters/adtran_generic/conf/sms_router.conf
@@ -1,4 +1,3 @@
-
 # CISCO_ISR
 path                                    adtran_generic
 asset-script-name                       adtran_generic_mgmt.php

--- a/adapters/adtran_generic/conf/sms_router.conf
+++ b/adapters/adtran_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 
 # CISCO_ISR
-model                                   16051901:16051902
 path                                    adtran_generic
 asset-script-name                       adtran_generic_mgmt.php

--- a/adapters/adva_nc/conf/sms_router.conf
+++ b/adapters/adva_nc/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # ADVA_GENERIC
-model                                   18100200:18100200
 report-model                            adva_nc
 path                                    adva_nc
 #asset-script-name                       adva_nc_mgmt.php

--- a/adapters/ansible_generic/conf/sms_router.conf
+++ b/adapters/ansible_generic/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # Ansible Generic
-model                                   22062020:22062020
 path                                    linux_generic
 

--- a/adapters/aws_generic/conf/sms_router.conf
+++ b/adapters/aws_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # AWS GENERIC
-model                                   17010301:17010301
 path                                    aws_generic
 asset-script-name                       aws_generic_mgmt.php
 poll-script-name                        aws_generic_poll.php

--- a/adapters/brocade_vyatta/conf/sms_router.conf
+++ b/adapters/brocade_vyatta/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # BROCADE_VYATTA
-model                                   15020201:15020201
 path                                    brocade_vyatta
 report-model                            Vyatta
 asset-script-name                       brocade_vyatta_mgmt.php

--- a/adapters/catalyst_ios/conf/sms_router.conf
+++ b/adapters/catalyst_ios/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_CATALYST_IOS
-model                                   1:104
 path                                    catalyst_ios
 asset-script-name                       catalyst_mgmt.php
 report-model                            IOS

--- a/adapters/checkpoint_r80/conf/sms_router.conf
+++ b/adapters/checkpoint_r80/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CHECKPOINT R80
-model                                   18082900:18082900
 report-model                            checkpoint_r80
 path                                    checkpoint_r80
 asset-script-name                       checkpoint_r80_mgmt.php

--- a/adapters/cisco_apic/conf/sms_router.conf
+++ b/adapters/cisco_apic/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # CISCO ENC 
-model                                   27:133
 path                                    cisco_apic    
 asset-script-name                       sdn_mgmt.php

--- a/adapters/cisco_asa_generic/conf/sms_router.conf
+++ b/adapters/cisco_asa_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_ASA_GENERIC
-model                                   1:15010202
 path                                    cisco_asa_generic
 report-model                            PIX_ASA
 asset-script-name                       cisco_asa_generic_mgmt.php

--- a/adapters/cisco_asa_rest/conf/sms_router.conf
+++ b/adapters/cisco_asa_rest/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_ASA_REST
-model                                   1:137
 path                                    cisco_asa_rest
 report-model                            CISCOASAREST
 asset-script-name                       cisco_asa_rest_mgmt.php

--- a/adapters/cisco_asr/conf/sms_router.conf
+++ b/adapters/cisco_asr/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_ASR
-model                                   1:14020802
 path                                    cisco_isr
 report-model                            IOS
 asset-script-name                       cisco_isr_mgmt.php

--- a/adapters/cisco_isr/conf/sms_router.conf
+++ b/adapters/cisco_isr/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_ISR
-model                                   1:113
 path                                    cisco_isr
 report-model                            IOS
 asset-script-name                       cisco_isr_mgmt.php

--- a/adapters/cisco_nexus9000/conf/sms_router.conf
+++ b/adapters/cisco_nexus9000/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_NEXUS9000
-model                                   1:201
 path                                    cisco_nexus9000
 report-model                            NEXUS9000
 asset-script-name                       cisco_nexus9000_mgmt.php

--- a/adapters/citrix_adc/conf/sms_router.conf
+++ b/adapters/citrix_adc/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CITRIX_ADC
-model                                   16020202:16020202
 report-model                            Netscaler
 path                                    citrix_adc
 asset-script-name                       citrix_netscaler_mgmt.php

--- a/adapters/dell_redfish/conf/sms_router.conf
+++ b/adapters/dell_redfish/conf/sms_router.conf
@@ -1,5 +1,3 @@
-#Dell Redfish API
+# Dell Redfish API
 path            dell_redfish
 model-data      {}
-
-

--- a/adapters/dell_redfish/conf/sms_router.conf
+++ b/adapters/dell_redfish/conf/sms_router.conf
@@ -1,5 +1,4 @@
 #Dell Redfish API
-model           1120120:11201201
 path            dell_redfish
 model-data      {}
 

--- a/adapters/esa/conf/sms_router.conf
+++ b/adapters/esa/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_ESA
-model                                   1:112
 path                                    esa
 report-model                            Cisco_ESA
 asset-script-name                       esa_mgmt.php

--- a/adapters/f5_bigip/conf/sms_router.conf
+++ b/adapters/f5_bigip/conf/sms_router.conf
@@ -1,3 +1,3 @@
-#F5 BIG-IP
+# F5 BIG-IP
 path                                    f5_bigip
 asset-script-name                       f5_bigip_mgmt.php

--- a/adapters/f5_bigip/conf/sms_router.conf
+++ b/adapters/f5_bigip/conf/sms_router.conf
@@ -1,4 +1,3 @@
 #F5 BIG-IP
-model                                   50000:50001
 path                                    f5_bigip
 asset-script-name                       f5_bigip_mgmt.php

--- a/adapters/fortigate/conf/sms_router.conf
+++ b/adapters/fortigate/conf/sms_router.conf
@@ -1,6 +1,5 @@
 
 # FORTINET_FORTIGATEVA
-model                                   17:15102617
 path                                    fortinet_generic
 report-model                            Fortinet
 asset-script-name                       fortinet_generic_mgmt.php

--- a/adapters/fortigate/conf/sms_router.conf
+++ b/adapters/fortigate/conf/sms_router.conf
@@ -1,4 +1,3 @@
-
 # FORTINET_FORTIGATEVA
 path                                    fortinet_generic
 report-model                            Fortinet

--- a/adapters/fortinet_fortianalyzer/conf/sms_router.conf
+++ b/adapters/fortinet_fortianalyzer/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # FORTINET_FORTIANALYZER
-model                                   17:18120702
 path                                    fortinet_jsonapi
 report-model                            Fortinet
 asset-script-name                       fortinet_jsonapi_mgmt.php

--- a/adapters/fortinet_fortimanager/conf/sms_router.conf
+++ b/adapters/fortinet_fortimanager/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # FORTINET_FORTIMANAGER
-model                                   17:18120701
 path                                    fortinet_jsonapi
 report-model                            Fortinet
 asset-script-name                       fortinet_jsonapi_mgmt.php

--- a/adapters/fortinet_generic/conf/sms_router.conf
+++ b/adapters/fortinet_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # FORTINET_GENERIC
-model                                   17:130
 path                                    fortinet_generic
 report-model                            Fortinet
 asset-script-name                       fortinet_generic_mgmt.php

--- a/adapters/fortinet_jsonapi/conf/sms_router.conf
+++ b/adapters/fortinet_jsonapi/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # FORTINET JSON API
-model                                   17:07062020
 path                                    fortinet_jsonapi
 report-model                            Fortinet
 asset-script-name                       fortinet_jsonapi_mgmt.php

--- a/adapters/fortiweb/conf/sms_router.conf
+++ b/adapters/fortiweb/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # FORTINET_FORTIWAF
-model                                   17:15031001
 path                                    fortinet_generic
 report-model                            Fortinet
 asset-script-name                       fortiwaf_mgmt.php

--- a/adapters/fujitsu_ipcom/conf/sms_router.conf
+++ b/adapters/fujitsu_ipcom/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # FUJITSU_IPCOM
-model                                   18100100:300
 path                                    fujitsu_ipcom
 report-model                            IOS
 asset-script-name                       fujitsu_ipcom_mgmt.php

--- a/adapters/hp2530/conf/sms_router.conf
+++ b/adapters/hp2530/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # hp2530
-model                                   17071301:17071301
 path                                    hp2530
 asset-script-name                       hp2530_mgmt.php

--- a/adapters/hp5900/conf/sms_router.conf
+++ b/adapters/hp5900/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # HP 5900
-model                                   17071301:17071302
 path                                    hp5900
 asset-script-name                       hp5900_mgmt.php

--- a/adapters/hpe_redfish/conf/sms_router.conf
+++ b/adapters/hpe_redfish/conf/sms_router.conf
@@ -1,8 +1,3 @@
-#Resdfish_API 
+# Resdfish_API
 path	        hpe_redfish	
 model-data	{}
-
-
-
-
-

--- a/adapters/hpe_redfish/conf/sms_router.conf
+++ b/adapters/hpe_redfish/conf/sms_router.conf
@@ -1,5 +1,4 @@
 #Resdfish_API 
-model		17071301:17171399
 path	        hpe_redfish	
 model-data	{}
 

--- a/adapters/huawei_generic/conf/sms_router.conf
+++ b/adapters/huawei_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # HUAWEI GENERIC
-model                                   17010201:17010201
 report-model                            Huawei
 path                                    huawei_generic
 asset-script-name                       huawei_generic_mgmt.php

--- a/adapters/intel_redfish/conf/sms_router.conf
+++ b/adapters/intel_redfish/conf/sms_router.conf
@@ -1,8 +1,3 @@
-#Resdfish_API 
+# Resdfish_API
 path		intel_redfish
 model-data	{}
-
-
-
-
-

--- a/adapters/intel_redfish/conf/sms_router.conf
+++ b/adapters/intel_redfish/conf/sms_router.conf
@@ -1,5 +1,4 @@
 #Resdfish_API 
-model		2120120:21201201
 path		intel_redfish
 model-data	{}
 

--- a/adapters/juniper_contrail/conf/sms_router.conf
+++ b/adapters/juniper_contrail/conf/sms_router.conf
@@ -1,3 +1,2 @@
 # JUNIPER_CONTRAIL
-model                                   18:138
 path                                    juniper_contrail

--- a/adapters/juniper_rest/conf/sms_router.conf
+++ b/adapters/juniper_rest/conf/sms_router.conf
@@ -1,4 +1,4 @@
-#Generic 
+# Generic
 path		juniper_rest
 model-data	{}
 

--- a/adapters/juniper_rest/conf/sms_router.conf
+++ b/adapters/juniper_rest/conf/sms_router.conf
@@ -1,5 +1,4 @@
 #Generic 
-model		18:191191
 path		juniper_rest
 model-data	{}
 

--- a/adapters/juniper_srx/conf/sms_router.conf
+++ b/adapters/juniper_srx/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # JUNIPER_SRX_2
-model                                   18:121
 report-model                            Juniper
 path                                    juniper_srx
 asset-script-name                       juniper_srx_mgmt.php

--- a/adapters/kubernetes_generic/conf/sms_router.conf
+++ b/adapters/kubernetes_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # KUBERNETES GENERIC
-model                                   20060101:20060101
 path                                    kubernetes_generic
 #asset-script-name                      kubernetes_generic_mgmt.php
 poll-script-name                        kubernetes_generic_poll.php

--- a/adapters/lanner_ipmi/conf/sms_router.conf
+++ b/adapters/lanner_ipmi/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # LANNER_IPMI
-model                                   20120801:20120801
 report-model                            IPMI
 path                                    lanner_ipmi

--- a/adapters/linux_generic/conf/sms_router.conf
+++ b/adapters/linux_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # LINUX_GENERIC
-model                                   14020601:14020601
 report-model                            Linux
 path                                    linux_generic
 asset-script-name                       linux_generic_mgmt.php

--- a/adapters/linux_k8_cli/conf/sms_router.conf
+++ b/adapters/linux_k8_cli/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # LINUX_GENERIC
-model                                   14020601:19112020
 report-model                            Linux
 path                                    linux_generic
 asset-script-name                       linux_generic_mgmt.php

--- a/adapters/mikrotik_generic/conf/sms_router.conf
+++ b/adapters/mikrotik_generic/conf/sms_router.conf
@@ -1,2 +1,1 @@
-model                                   23062020:23062020
 path                                    mikrotik_generic

--- a/adapters/mikrotik_generic/conf/sms_router.conf
+++ b/adapters/mikrotik_generic/conf/sms_router.conf
@@ -1,1 +1,2 @@
+# MIKROTIC
 path                                    mikrotik_generic

--- a/adapters/mon_checkpoint_fw/conf/sms_router.conf
+++ b/adapters/mon_checkpoint_fw/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CHECKPOINT_FIREWALL
-model                                   770000:770011
 path                                    mon_generic
 report-model                            Checkpoint
 asset-script-name                       mon_generic_mgmt.php

--- a/adapters/mon_cisco_asa/conf/sms_router.conf
+++ b/adapters/mon_cisco_asa/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_ASA_MONITOR_ONLY
-model                                   770000:770016
 path                                    mon_generic
 report-model                            PIX_ASA
 asset-script-name                       mon_asa_mgmt.php

--- a/adapters/mon_cisco_ios/conf/sms_router.conf
+++ b/adapters/mon_cisco_ios/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_ISR_IOS_MONITOR_ONLY
-model                                   770000:770014
 path                                    mon_generic
 report-model                            IOS
 asset-script-name                       mon_cisco_mgmt.php

--- a/adapters/mon_fortinet_fortigate/conf/sms_router.conf
+++ b/adapters/mon_fortinet_fortigate/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # FORTINET_FORTIGATE_MONITOR_ONLY
-model                                   770000:770012
 path                                    mon_generic
 report-model                            Fortinet
 asset-script-name                       mon_fortinet_mgmt.php

--- a/adapters/mon_generic/conf/sms_router.conf
+++ b/adapters/mon_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # GENERIC_GENERIC
-model                                   770000:770010
 path                                    mon_generic
 asset-script-name                       mon_generic_mgmt.php
 report-model                            GENERIC

--- a/adapters/nec_intersecvmlb/conf/sms_router.conf
+++ b/adapters/nec_intersecvmlb/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # NEC_INTERSECVMLB
-model                                   70000:7000001
 path                                    nec_intersecvmlb
 report-model                            NEC
 asset-script-name                       nec_intersecvmlb_mgmt.php

--- a/adapters/nec_intersecvmsg/conf/sms_router.conf
+++ b/adapters/nec_intersecvmsg/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # NEC_INTERSECVMSG
-model                                   70000:7000006
 path                                    nec_intersecvmsg
 report-model                            NEC
 asset-script-name                       nec_intersecvmsg_mgmt.php

--- a/adapters/nec_ix/conf/sms_router.conf
+++ b/adapters/nec_ix/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # NEC_IX2000
-model                                   70000:7000002
 path                                    nec_ix
 report-model                            NEC
 asset-script-name                       nec_ix_mgmt.php

--- a/adapters/nec_nfa/conf/sms_router.conf
+++ b/adapters/nec_nfa/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # NEC PFLOW PFC Switch Config API
-model                                   70000:7000003
 path                                    nec_nfa
 report-model                            NECNFA
 

--- a/adapters/nec_pflow_p4_unc/conf/sms_router.conf
+++ b/adapters/nec_pflow_p4_unc/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # NEC PFLOW P4 UNC
-model                                   70000:7000004
 path                                    nec_pflow_p4_unc
 asset-script-name                       nec_pflow_p4_unc_mgmt.php
 

--- a/adapters/nec_pflow_pfcscapi/conf/sms_router.conf
+++ b/adapters/nec_pflow_pfcscapi/conf/sms_router.conf
@@ -1,3 +1,2 @@
 # NEC PFLOW PFC Switch Config API
-model                                   70000:7000005
 path                                    nec_pflow_pfcscapi

--- a/adapters/netconf_generic/conf/sms_router.conf
+++ b/adapters/netconf_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # NETCONF_GENERIC
-model                                   18072500:18072500
 #report-model
 path                                    netconf_generic
 asset-script-name                       netconf_generic_mgmt.php

--- a/adapters/nfvo_generic/conf/sms_router.conf
+++ b/adapters/nfvo_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # OPENSTACK_KEYSTONE_V3
-model                                   17010303:17010305
 report-model                            NFVO 
 path                                    nfvo_generic
 poll-script-name                        nfvo_generic_poll.php

--- a/adapters/nokia_cloudband/conf/sms_router.conf
+++ b/adapters/nokia_cloudband/conf/sms_router.conf
@@ -1,3 +1,2 @@
 # LINUX_GENERIC
-model                                   27082020:2708202001
 path                                    nokia_cloudband

--- a/adapters/nokia_vsd/conf/sms_router.conf
+++ b/adapters/nokia_vsd/conf/sms_router.conf
@@ -1,3 +1,2 @@
 # LINUX_GENERIC
-model                                   27082020:2708202002
 path                                    nokia_vsd

--- a/adapters/oneaccess_lbb/conf/sms_router.conf
+++ b/adapters/oneaccess_lbb/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # ONEACCESS_LBB
-model                                   25:110
 path                                    oneaccess_lbb
 asset-script-name                       oneaccess_lbb_mgmt.php

--- a/adapters/oneaccess_netconf/conf/sms_router.conf
+++ b/adapters/oneaccess_netconf/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # ONEACCESS NETCONF
-model                                   25:16010411
 path                                    netconf_generic
 asset-script-name                       oneaccess_lbb_mgmt.php
 

--- a/adapters/oneaccess_whitebox/conf/sms_router.conf
+++ b/adapters/oneaccess_whitebox/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # ONEACCESS WHITE BOX
-model                                   25:16010402
 path                                    netconf_generic
 asset-script-name                       oneaccess_lbb_mgmt.php

--- a/adapters/opendaylight/conf/sms_router.conf
+++ b/adapters/opendaylight/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # OPENDAYLIGHT
-model                                   27:131
 path                                    opendaylight
 asset-script-name                       sdn_mgmt.php
 poll-script-name                        opendaylight_poll.php

--- a/adapters/openstack_keystone_v3/conf/sms_router.conf
+++ b/adapters/openstack_keystone_v3/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # OPENSTACK_KEYSTONE_V3
-model                                   14020603:16051904
 report-model                            OpenStack
 path                                    openstack_keystone_v3
 #asset-script-name                       openstack_generic_mgmt.php

--- a/adapters/paloalto_chassis/conf/sms_router.conf
+++ b/adapters/paloalto_chassis/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # PALOALTO_CHASSIS
-model                                   28:135
 path                                    paloalto_generic
 report-model                            PALOALTO
 asset-script-name                       paloalto_generic_mgmt.php

--- a/adapters/paloalto_generic/conf/sms_router.conf
+++ b/adapters/paloalto_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # PALOALTO_GENERIC
-model                                   28:134
 path                                    paloalto_generic
 report-model                            PALOALTO
 asset-script-name                       paloalto_generic_mgmt.php

--- a/adapters/paloalto_vsys/conf/sms_router.conf
+++ b/adapters/paloalto_vsys/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # PALOALTO_VSYS
-model                                   28:136
 path                                    paloalto_generic
 report-model                            PALOALTO
 asset-script-name                       paloalto_generic_mgmt.php

--- a/adapters/pfsense_fw/conf/sms_router.conf
+++ b/adapters/pfsense_fw/conf/sms_router.conf
@@ -1,4 +1,3 @@
 #Generic 
-model		200425:200425
 path		pfsense_fw
 model-data	{}

--- a/adapters/pfsense_fw/conf/sms_router.conf
+++ b/adapters/pfsense_fw/conf/sms_router.conf
@@ -1,3 +1,3 @@
-#Generic 
+# Generic
 path		pfsense_fw
 model-data	{}

--- a/adapters/rancher_cmp/conf/sms_router.conf
+++ b/adapters/rancher_cmp/conf/sms_router.conf
@@ -1,4 +1,3 @@
 # Rancher CMP
-model                                   18081001:18081001
 path                                    rancher_cmp
 poll-script-name                        rancher_cmp_poll.php

--- a/adapters/rest_generic/conf/sms_router.conf
+++ b/adapters/rest_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 #Generic 
-model		191119:191119
 path		rest_generic
 model-data	{}
 

--- a/adapters/rest_generic/conf/sms_router.conf
+++ b/adapters/rest_generic/conf/sms_router.conf
@@ -1,4 +1,4 @@
-#Generic 
+# Generic
 path		rest_generic
 model-data	{}
 

--- a/adapters/rest_netbox/conf/sms_router.conf
+++ b/adapters/rest_netbox/conf/sms_router.conf
@@ -1,4 +1,4 @@
-#Generic 
+# Generic
 path		rest_generic
 model-data	{}
 

--- a/adapters/rest_netbox/conf/sms_router.conf
+++ b/adapters/rest_netbox/conf/sms_router.conf
@@ -1,5 +1,4 @@
 #Generic 
-model		191119:29092020
 path		rest_generic
 model-data	{}
 

--- a/adapters/stormshield/conf/sms_router.conf
+++ b/adapters/stormshield/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # Stormshield Generic
-model                                   16010401:16010401
 path                                    stormshield
 asset-script-name                       netasq_mgmt.php
 poll-script-name                        netasq_availability.php

--- a/adapters/veex_rtu/conf/sms_router.conf
+++ b/adapters/veex_rtu/conf/sms_router.conf
@@ -1,3 +1,2 @@
 # VEEX RTU
-model                                   17010302:17010302
 path                                    veex_rtu

--- a/adapters/versa_analytics/conf/sms_router.conf
+++ b/adapters/versa_analytics/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # VERSA_ANALYTICS
-model                                   14020602:14020603
 report-model                            Versa
 path                                    versa_analytics
 #asset-script-name                       versa_analytics_mgmt.php

--- a/adapters/versa_appliance/conf/sms_router.conf
+++ b/adapters/versa_appliance/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # VERSA_APPLIANCE
-model                                   14020602:14020604
 report-model                            Versa
 path                                    versa_appliance
 #asset-script-name                       versa_appliance_mgmt.php

--- a/adapters/versa_director/conf/sms_router.conf
+++ b/adapters/versa_director/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # VERSA_DIRECTOR
-model                                   14020602:14020602
 report-model                            Versa
 path                                    versa_director
 #asset-script-name                       versa_director_mgmt.php

--- a/adapters/virtuora_nc/conf/sms_router.conf
+++ b/adapters/virtuora_nc/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # Fujistsu Virtuora NC
-model                                   18100100:18100100
 report-model                            virtuora_nc
 path                                    virtuora_nc
 #asset-script-name                       virtuora_nc_mgmt.php

--- a/adapters/vmware_vsphere/conf/sms_router.conf
+++ b/adapters/vmware_vsphere/conf/sms_router.conf
@@ -1,4 +1,4 @@
-#VMWare vSPHERE
+# VMWare vSPHERE
 report-model                            VMWare
 path                                    vmware_vsphere
 asset-script-name                       vmware_vsphere_mgmt.php

--- a/adapters/vmware_vsphere/conf/sms_router.conf
+++ b/adapters/vmware_vsphere/conf/sms_router.conf
@@ -1,5 +1,4 @@
 #VMWare vSPHERE
-model                                   24:17010204
 report-model                            VMWare
 path                                    vmware_vsphere
 asset-script-name                       vmware_vsphere_mgmt.php

--- a/adapters/vnfm_generic/conf/sms_router.conf
+++ b/adapters/vnfm_generic/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # OPENSTACK_KEYSTONE_V3
-model                                   17010304:17010306 
 report-model                            VNFM
 path                                    vnfm_generic
 poll-script-name                        vnfm_generic_poll.php

--- a/adapters/wsa/conf/sms_router.conf
+++ b/adapters/wsa/conf/sms_router.conf
@@ -1,5 +1,4 @@
 # CISCO_WSA
-model                                   1:95
 path                                    wsa
 report-model                            Cisco_WSA
 asset-script-name                       wsa_mgmt.php

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -50,7 +50,7 @@ da_install() {
 
 	read_properties_files
 	#check_create_model
-	check_sms_router_conf
+	patch_sms_router_conf
 	update_files
 }
 
@@ -69,7 +69,6 @@ da_uninstall() {
 	DA_SRC_PATH=basename $DA_DIR
 
 	read_properties_files
-	check_sms_router_conf
 
 	target_file="$JENTREPRISE_CONF/custom/models.properties"
 	default_file="$JENTREPRISE_CONF/models.properties"
@@ -97,7 +96,6 @@ da_deactivate() {
 	DA_SRC_PATH=basename $DA_DIR
 
 	read_properties_files
-	check_sms_router_conf
 
 	target_file="$JENTREPRISE_CONF/custom/models.properties"
 	default_file="$JENTREPRISE_CONF/models.properties"
@@ -201,19 +199,13 @@ read_properties_files() {
 #	fi
 }
 
-check_sms_router_conf() {
+patch_sms_router_conf() {
 	sms_router_conf="$CONF_DIR/sms_router.conf"
 	[ -f "$DA_DIR/$sms_router_conf" ] || \
 		fatal "file not found: $sms_router_conf"
 
-	spec=$(cat $DA_DIR/$sms_router_conf | egrep '^model\s' | awk '{print $2}')
-	man_id=$(cut -d : -f 1 <<< "$spec")
-	mod_id=$(cut -d : -f 2 <<< "$spec")
-
-	[ "$man_id" = "$MAN_ID" ] || \
-		fatal "inconsistent definition: man_id=$man_id MAN_ID=$MAN_ID"
-	[ "$mod_id" = "$MOD_ID" ] || \
-		fatal "inconsistent definition: mod_id=$mod_id MOD_ID=$MOD_ID"
+	sed -i "/^model[^-]/ d"			$DA_DIR/$sms_router_conf
+	sed -i "1 i model $MAN_ID:$MOD_ID"	$DA_DIR/$sms_router_conf
 }
 
 read_property() {


### PR DESCRIPTION
Device «model» information (`<man-id>:<mod-id>`) is duplicated in files `conf/sms_router.conf` and `conf/device.conf`.
- remove model info from source file `sms router.conf`
- generate line `model <man-id>:<mod-id>` at install time instead