### PR TITLE
Fixing the line config comparison from integer to string for Catalyst DA

### DIFF
--- a/adapters/catalyst_ios/catalyst_ios_apply_conf.php
+++ b/adapters/catalyst_ios/catalyst_ios_apply_conf.php
@@ -53,7 +53,7 @@ function catalyst_ios_apply_conf($configuration)
 	// SCP mode configuration (default mode)
 	// ---------------------------------------------------
 	$ret = SMS_OK;
-	if ($protocol === 'SSH' && ($line_config_mode === 0 || $line_config_mode === 3))
+	if ($protocol === 'SSH' && ($line_config_mode === '0' || $line_config_mode === '3'))
 	{
 		echo "SCP mode configuration\n";
 
@@ -105,7 +105,7 @@ function catalyst_ios_apply_conf($configuration)
 	// Line by line mode configuration - Used for ZTD port console
 	// ---------------------------------------------------
 	$ret = SMS_OK;
-	if ($line_config_mode === 1 || $protocol === 'CONSOLE')
+	if ($line_config_mode === '1' || $protocol === 'CONSOLE')
 	{
 		echo "Line by line mode configuration\n";
 		$ERROR_BUFFER ='';


### PR DESCRIPTION
We need this fix to have the behavior as expected as currently the DA is falling back to tftp even if the line_config_mode is 0