### PR TITLE
Revert "Fixing the line config comparison from integer to string for Catalyst DA"

### DIFF
--- a/adapters/catalyst_ios/catalyst_ios_apply_conf.php
+++ b/adapters/catalyst_ios/catalyst_ios_apply_conf.php
@@ -53,7 +53,7 @@ function catalyst_ios_apply_conf($configuration)
 	// SCP mode configuration (default mode)
 	// ---------------------------------------------------
 	$ret = SMS_OK;
-	if ($protocol === 'SSH' && ($line_config_mode === '0' || $line_config_mode === '3'))
+	if ($protocol === 'SSH' && ($line_config_mode === 0 || $line_config_mode === 3))
 	{
 		echo "SCP mode configuration\n";
 
@@ -105,7 +105,7 @@ function catalyst_ios_apply_conf($configuration)
 	// Line by line mode configuration - Used for ZTD port console
 	// ---------------------------------------------------
 	$ret = SMS_OK;
-	if ($line_config_mode === '1' || $protocol === 'CONSOLE')
+	if ($line_config_mode === 1 || $protocol === 'CONSOLE')
 	{
 		echo "Line by line mode configuration\n";
 		$ERROR_BUFFER ='';


### PR DESCRIPTION
Reverts openmsa/Adapters#135
Be careful that PR135 will work for 2.2 but not for 2.3 because the fix was done in C code for all the DAs.
The fix is in the php data file. for example in 2.2 there was
$sd->SD_CONFIG_STEP = '0';
and in 2.3
$sd->SD_CONFIG_STEP = 0;

2.3GA will be available soon, maybe today or tomorrow. I think it should be better to upgrade to 2.3